### PR TITLE
Fix appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,9 +24,12 @@ install:
   - timeout 10
   - cd %ILASTIK_ROOT%\ilastik-meta
   - >
-    python ilastik/scripts/devenv.py create -n %ENV_NAME%
-    -p ilastik-dependencies-no-solvers pytest-cov coveralls black
-    -c ilastik-forge conda-forge defaults
+    conda create -n %ENV_NAME%
+    -c ilastik-forge -c conda-forge -c defaults
+    ilastik-dependencies-no-solvers
+    pytest-cov
+    coveralls
+    black
 
 build: off
 
@@ -35,7 +38,7 @@ test_script:
   - activate %ENV_NAME%
   - cd %ILASTIK_ROOT%\ilastik-meta\lazyflow
   - >
-      pytest
+      python -m pytest
       --capture=no
       --junitxml=nosetests.lazyflow.xml
 

--- a/lazyflow/roi.py
+++ b/lazyflow/roi.py
@@ -428,7 +428,7 @@ def nonzero_bounding_box(data):
         >>> data = numpy.zeros( (10,100,100) )
         >>> data[4, 30:40, 50:60] = 1
         >>> data[7, 45:55, 30:35] = 255
-        >>> nonzero_bounding_box(data)
+        >>> nonzero_bounding_box(data).astype("int")
         array([[ 4, 30, 30],
                [ 8, 55, 60]])
 

--- a/lazyflow/utility/jsonConfig.py
+++ b/lazyflow/utility/jsonConfig.py
@@ -226,9 +226,9 @@ class JsonConfigParser(object):
     ... }
     ... \"""
     >>> import os, tempfile
-    >>> configFile = tempfile.NamedTemporaryFile(delete=False)
-    >>> with open(configFile.name, 'w') as f:
-    ...     _ = f.write(example_file_str)
+    >>> configFile = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    >>> _ = configFile.write(example_file_str)
+    >>> configFile.close()
     >>>
     >>> # Create a parser that understands your schema
     >>> parser = JsonConfigParser( SchemaFields )


### PR DESCRIPTION
Fixing the appveyor tests by:

* not installing `ilastik-meta` (or removing it)
* fixing doctests that have diffferent behavior on windows:
  * `jsonConfig`: open files cannot be removed on windows -> close file
  * `roi`: default dtype on windows for ints is different, printing of those, hence, include dtype -> cast to `numpy.int`